### PR TITLE
Add dual CJS/ESM support with conditional exports

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ function wrapper to catch errors in [express](https://expressjs.com/) controller
 
 to install: `npm i amk-wrap`
 
-can pass a function or a class method.
+can pass a function or a class method. Supports both CommonJS (`require`) and ESM (`import`).
+
+### CommonJS
 
 on the router file:
-```
+```js
 const express = require('express');
 const router = express.Router();
 const wrap = require('amk-wrap');
@@ -32,11 +34,10 @@ module.exports = function (controller) {
   router.get('/', wrap(controller, 'get')); // pass a class method
   return router;
 }
-
 ```
 
 on the index.js:
-```
+```js
 const wrap = require('amk-wrap');
 
 // some other code
@@ -44,8 +45,28 @@ const wrap = require('amk-wrap');
 app.get('/', wrap(getFunction)); // pass a function
 ```
 or
-```
+```js
 const wrap = require('amk-wrap');
+
+// some other code
+
+app.get('/', wrap((req, res) => {
+	res.send('hello world');
+}));
+```
+
+### ESM
+
+```js
+import wrap from 'amk-wrap';
+
+// some other code
+
+app.get('/', wrap(getFunction)); // pass a function
+```
+or
+```js
+import wrap from 'amk-wrap';
 
 // some other code
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,3 @@
+import wrapper from './lib/wrapper.js';
+
+export default wrapper;

--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "import": "./index.mjs"
-    }
+      "import": "./index.mjs",
+      "default": "./index.js"
+    },
+    "./lib/wrapper": "./lib/wrapper.js",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,17 @@
 {
   "name": "amk-wrap",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "function wrapper to catch errors in express.js controllers",
   "main": "index.js",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs"
+    }
+  },
   "scripts": {
     "lint": "eslint .",
-    "test": "c8 node --test test/index.js"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -83,4 +83,19 @@ describe('Wrapper function', () => {
     expect(err).toBeInstanceOf(TypeError);
     expect(err.message).toBe('Invalid arguments');
   });
+
+  it('Should expose the wrapper via a CJS subpath import', () => {
+    const wrapper = require('amk-wrap/lib/wrapper');
+    expect(typeof wrapper).toBe('function');
+  });
+
+  it('Should expose package.json via a CJS subpath import', () => {
+    const pkg = require('amk-wrap/package.json');
+    expect(pkg.name).toBe('amk-wrap');
+  });
+
+  it('Should support ESM default import from index.mjs', async () => {
+    const { default: wrapESM } = await import('../index.mjs');
+    expect(typeof wrapESM).toBe('function');
+  });
 });


### PR DESCRIPTION
## What?

- Adds native ESM support while preserving full CommonJS backward compatibility.
- Bumps version to `1.0.0`.
- Updates the test script to run without `c8` to avoid a `yargs`/`c8` crash on Node.js 26.
- Expands the CI matrix to Node.js 22.x, 24.x, and 26.x.
- Updates documentation (`README.md`, `AGENTS.md`) to reflect dual-mode usage and current tooling.
- Expands `package.json` `exports` to explicitly expose `./lib/wrapper` and `./package.json`, and adds a `default` fallback for non-Node resolvers.
- Adds tests for subpath CJS imports and the ESM default import.

## Why?

- ESM is the standard module system in modern Node.js, and consumers increasingly expect packages to support `import`.
- Without conditional exports, migrating to ESM would break CJS consumers with `ERR_REQUIRE_ESM`.
- `c8` (via `yargs`) crashes on Node.js 26 with `ReferenceError: require is not defined in ES module scope` (see [bcoe/c8#592](https://github.com/bcoe/c8/issues/592)), so the test command skips coverage until that upstream issue is resolved.
- Review feedback pointed out that adding an `exports` map without subpath entries breaks deep imports such as `require('amk-wrap/lib/wrapper')` and `require('amk-wrap/package.json')`, which contradicts the goal of preserving full backward compatibility.

## How?

- Created `index.mjs` as a thin ESM wrapper that imports `lib/wrapper.js` and re-exports it as the default.
- Added a conditional `exports` map in `package.json` that now also exposes the wrapper subpath and `package.json`, plus a `default` fallback:
  ```json
  "exports": {
    ".": {
      "require": "./index.js",
      "import": "./index.mjs",
      "default": "./index.js"
    },
    "./lib/wrapper": "./lib/wrapper.js",
    "./package.json": "./package.json"
  }
  ```
- Changed `npm test` from `c8 node --test test/index.js` to `node --test`.
- Kept `c8` in `devDependencies` and the Codecov upload step in CI so coverage can be re-enabled later without re-adding infrastructure.
- Updated CI runner to `ubuntu-24.04` and matrix to `[22.x, 24.x, 26.x]`.
- Added regression tests in `test/index.js` covering:
  - `require('amk-wrap/lib/wrapper')`
  - `require('amk-wrap/package.json')`
  - `await import('../index.mjs')`

## Testing?

- `npm test` passes on Node.js 22.x, 24.x, and 26.x (10/10 tests).
- Verified ESM import works: `node --input-type=module -e "import wrap from './index.mjs'; console.log(typeof wrap)"` outputs `function`.
- Verified CJS require still works: `const wrap = require('amk-wrap')` resolves correctly.
- Verified subpath CJS imports work:
  - `require('amk-wrap/lib/wrapper')` returns the wrapper function.
  - `require('amk-wrap/package.json')` returns the package manifest.

## Screenshots (optional)

N/A

## Anything Else?

- `c8` coverage is temporarily disabled from the test script only; the dependency and CI upload step remain in place for easy re-enablement once [bcoe/c8#592](https://github.com/bcoe/c8/issues/592) is resolved.

## AI Summary (optional)

This PR introduces dual-mode CommonJS + ESM support for `amk-wrap` using Node.js conditional exports. It adds an `index.mjs` wrapper, updates `package.json` exports, bumps the version to `1.0.0`, and adjusts the test script to bypass `c8` due to a Node.js 26 incompatibility. It also addresses review feedback by explicitly exporting `./lib/wrapper` and `./package.json`, adding a `default` fallback, and includes regression tests for subpath resolution and ESM import.
