### PR TITLE
add typescript support

### DIFF
--- a/lib/wrapper.d.ts
+++ b/lib/wrapper.d.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from 'express';
+
+declare function wrap(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown> | unknown
+): (req: Request, res: Response, next: NextFunction) => void;
+
+declare function wrap<T extends Record<string, any>>(
+  context: T,
+  methodName: keyof T
+): (req: Request, res: Response, next: NextFunction) => void;
+
+declare namespace wrap {
+  export type AsyncRequestHandler = (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => Promise<unknown> | unknown;
+}
+
+export = wrap;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "amk-wrap",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amk-wrap",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "~10.0.1",
+        "@types/express": "^5.0.6",
         "c8": "~11.0.0",
         "eslint": "~10.4.1",
         "expect": "~30.4.1",
-        "globals": "~17.6.0"
+        "globals": "~17.6.0",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -369,6 +371,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -380,6 +403,38 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -425,6 +480,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1705,6 +1795,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -3,13 +3,18 @@
   "version": "1.0.0",
   "description": "function wrapper to catch errors in express.js controllers",
   "main": "index.js",
+  "types": "lib/wrapper.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/wrapper.d.ts",
       "require": "./index.js",
       "import": "./index.mjs",
       "default": "./index.js"
     },
-    "./lib/wrapper": "./lib/wrapper.js",
+    "./lib/wrapper": {
+      "types": "./lib/wrapper.d.ts",
+      "default": "./lib/wrapper.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -29,9 +34,11 @@
   "type": "commonjs",
   "devDependencies": {
     "@eslint/js": "~10.0.1",
+    "@types/express": "~5.0.6",
     "c8": "~11.0.0",
     "eslint": "~10.4.1",
     "expect": "~30.4.1",
-    "globals": "~17.6.0"
+    "globals": "~17.6.0",
+    "typescript": "~6.0.3"
   }
 }


### PR DESCRIPTION
## What?

Adds first-party TypeScript type declarations for `amk-wrap`, enabling full IntelliSense and type-checking for both CommonJS and ESM consumers without requiring any additional `@types/*` package.

## Why?

The library has been JavaScript-only so far. TypeScript users had no type safety when importing `wrap`, and Express middleware authors could not get autocompletion for the two call signatures (standalone function vs. class-method wrapper).

## How?

- Created `lib/wrapper.d.ts` with:
  - Overloaded `wrap(fn)` for standalone async handlers.
  - Overloaded `wrap(context, methodName)` for class-method wrappers preserving `this`.
  - Exported `AsyncRequestHandler` type for consumers who want to type their own handlers.
- Updated `package.json`:
  - Added top-level `"types"` field.
  - Added `"types"` conditional export for `.` and `./lib/wrapper` so both `require` and `import` users get types automatically.
- Added dev dependencies (`@types/express`, `typescript`) to validate declarations during development.

## Testing?

- No runtime code was changed, so the existing `node --test` suite still passes.
- The `.d.ts` file was written to match the existing runtime behavior validated by the tests.

## Screenshots (optional)

N/A

## Anything Else?

- This is a backward-compatible additive change; no breaking changes for JS consumers.
- After merge, we can cut the `1.0.0` release (the version in `package.json` is already bumped).

## AI Summary (optional)

N/A
